### PR TITLE
Use correct name for scikit-learn PyPI package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description_content_type='text/markdown',  # This is important!
     author='StatguyUser',
     url='https://github.com/StatguyUser/BaselineRemoval',
-    install_requires=['numpy','sklearn','scipy'],
+    install_requires=['numpy','scikit-learn','scipy'],
     download_url='https://github.com/StatguyUser/BaselineRemoval.git',
     py_modules=["BaselineRemoval"],
     package_dir={'':'src'},


### PR DESCRIPTION
Hi, scikit-learn core devloper here :wave:

We are trying to discourage people from using the `sklearn` package rather than `scikit-learn`. See https://github.com/scikit-learn/scikit-learn/issues/8215#issuecomment-344679114 about why.

If you are interested by how I ended up making a PR. Your package came up in a Pyodide issue https://github.com/pyodide/pyodide/discussions/2989

